### PR TITLE
mis named a strategy

### DIFF
--- a/middleware/passportConfig.js
+++ b/middleware/passportConfig.js
@@ -91,7 +91,7 @@ module.exports = function(passport) {
     // =========================================================================
     // FACEBOOK ================================================================
     // =========================================================================
-    passport.use(new FacebookStrategy({
+    passport.use(new facebook({
 
         // pull in our app id and secret from our auth.js file
         clientID        : 482046309075252,


### PR DESCRIPTION
Named a strategy in passport facebook but then called it later as FacebookStrategy. Fixed it. Now it is all known as "facebook"
